### PR TITLE
Adds a TypeConverter

### DIFF
--- a/Amplified.CSharp.Tests/Amplified.CSharp.Tests.csproj
+++ b/Amplified.CSharp.Tests/Amplified.CSharp.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <!--<Import Project="..\packages\xunit.core\2.2.0\build\uap10.0\xunit.core.props" Condition="Exists('..\packages\xunit.core\2.2.0\build\uap10.0\xunit.core.props')" />-->
   <PropertyGroup>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFrameworks>netcoreapp1.1;net46</TargetFrameworks>
     <AssemblyName>Amplified.CSharp.Tests</AssemblyName>
     <PackageId>Amplified.CSharp.Tests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>

--- a/Amplified.CSharp.Tests/Amplified.CSharp.Tests.csproj
+++ b/Amplified.CSharp.Tests/Amplified.CSharp.Tests.csproj
@@ -5,8 +5,6 @@
     <AssemblyName>Amplified.CSharp.Tests</AssemblyName>
     <PackageId>Amplified.CSharp.Tests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
-    <NetStandardImplicitPackageVersion>1.6.0</NetStandardImplicitPackageVersion>
-    <RuntimeFrameworkVersion>1.1.1</RuntimeFrameworkVersion>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>

--- a/Amplified.CSharp.Tests/Amplified.CSharp.Tests.csproj
+++ b/Amplified.CSharp.Tests/Amplified.CSharp.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <!--<Import Project="..\packages\xunit.core\2.2.0\build\uap10.0\xunit.core.props" Condition="Exists('..\packages\xunit.core\2.2.0\build\uap10.0\xunit.core.props')" />-->
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp1.1;net46</TargetFrameworks>
+    <TargetFrameworks>netcoreapp1.1;net452</TargetFrameworks>
     <AssemblyName>Amplified.CSharp.Tests</AssemblyName>
     <PackageId>Amplified.CSharp.Tests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>

--- a/Amplified.CSharp.Tests/AsyncMaybe/Match__Func_T_Task__Func_None_Task.cs
+++ b/Amplified.CSharp.Tests/AsyncMaybe/Match__Func_T_Task__Func_None_Task.cs
@@ -12,7 +12,7 @@ namespace Amplified.CSharp
         {
             var invocations = 0;
             var source = AsyncMaybe<int>.None();
-            var result = await source.Match(some => Task.CompletedTask, none => { invocations++; return Task.CompletedTask; });
+            var result = await source.Match(some => TaskCache.CompletedTask, none => { invocations++; return TaskCache.CompletedTask; });
             Assert.Equal(Unit(), result);
             Assert.Equal(1, invocations);
         }
@@ -21,35 +21,35 @@ namespace Amplified.CSharp
         public async Task WithLambdas()
         {
             var source = AsyncMaybe<int>.Some(1);
-            var result = await source.Match(some => Task.CompletedTask, none => Task.CompletedTask);
+            var result = await source.Match(some => TaskCache.CompletedTask, none => TaskCache.CompletedTask);
             Assert.Equal(Unit(), result);
         }
         
         [Fact]
         public async Task WithSomeLambda_AndNoneReference()
         {
-            Task MatchNone(None none) => Task.CompletedTask;
+            Task MatchNone(None none) => TaskCache.CompletedTask;
             
             var source = AsyncMaybe<int>.Some(1);
-            var result = await source.Match(someAsync: some => Task.CompletedTask, noneAsync: MatchNone);
+            var result = await source.Match(someAsync: some => TaskCache.CompletedTask, noneAsync: MatchNone);
             Assert.Equal(Unit(), result);
         }
         
         [Fact]
         public async Task WithSomeReference_AndNoneLambda()
         {
-            Task MatchSome(int some) => Task.CompletedTask;
+            Task MatchSome(int some) => TaskCache.CompletedTask;
             
             var source = AsyncMaybe<int>.Some(1);
-            var result = await source.Match(someAsync: MatchSome, noneAsync: none => Task.CompletedTask);
+            var result = await source.Match(someAsync: MatchSome, noneAsync: none => TaskCache.CompletedTask);
             Assert.Equal(Unit(), result);
         }
         
         [Fact]
         public async Task WithReferences()
         {
-            Task MatchSome(int some) => Task.CompletedTask;
-            Task MatchNone(None none) => Task.CompletedTask;
+            Task MatchSome(int some) => TaskCache.CompletedTask;
+            Task MatchNone(None none) => TaskCache.CompletedTask;
             
             var source = AsyncMaybe<int>.Some(1);
             var result = await source.Match(someAsync: MatchSome, noneAsync: MatchNone);

--- a/Amplified.CSharp.Tests/AsyncMaybe/Match__Func_T_Task__Func_Task.cs
+++ b/Amplified.CSharp.Tests/AsyncMaybe/Match__Func_T_Task__Func_Task.cs
@@ -12,7 +12,7 @@ namespace Amplified.CSharp
         {
             var invocations = 0;
             var source = AsyncMaybe<int>.None();
-            var result = await source.Match(some => Task.CompletedTask, () => { invocations++; return Task.CompletedTask; });
+            var result = await source.Match(some => TaskCache.CompletedTask, () => { invocations++; return TaskCache.CompletedTask; });
             Assert.Equal(Unit(), result);
             Assert.Equal(1, invocations);
         }
@@ -21,35 +21,35 @@ namespace Amplified.CSharp
         public async Task WithLambdas()
         {
             var source = AsyncMaybe<int>.Some(1);
-            var result = await source.Match(some => Task.CompletedTask, () => Task.CompletedTask);
+            var result = await source.Match(some => TaskCache.CompletedTask, () => TaskCache.CompletedTask);
             Assert.Equal(Unit(), result);
         }
         
         [Fact]
         public async Task WithSomeLambda_AndNoneReference()
         {
-            Task MatchNone() => Task.CompletedTask;
+            Task MatchNone() => TaskCache.CompletedTask;
             
             var source = AsyncMaybe<int>.Some(1);
-            var result = await source.Match(someAsync: some => Task.CompletedTask, noneAsync: MatchNone);
+            var result = await source.Match(someAsync: some => TaskCache.CompletedTask, noneAsync: MatchNone);
             Assert.Equal(Unit(), result);
         }
         
         [Fact]
         public async Task WithSomeReference_AndNoneLambda()
         {
-            Task MatchSome(int some) => Task.CompletedTask;
+            Task MatchSome(int some) => TaskCache.CompletedTask;
             
             var source = AsyncMaybe<int>.Some(1);
-            var result = await source.Match(someAsync: MatchSome, noneAsync: () => Task.CompletedTask);
+            var result = await source.Match(someAsync: MatchSome, noneAsync: () => TaskCache.CompletedTask);
             Assert.Equal(Unit(), result);
         }
         
         [Fact]
         public async Task WithReferences()
         {
-            Task MatchSome(int some) => Task.CompletedTask;
-            Task MatchNone() => Task.CompletedTask;
+            Task MatchSome(int some) => TaskCache.CompletedTask;
+            Task MatchNone() => TaskCache.CompletedTask;
             
             var source = AsyncMaybe<int>.Some(1);
             var result = await source.Match(someAsync: MatchSome, noneAsync: MatchNone);

--- a/Amplified.CSharp.Tests/AsyncMaybe/TaskCache.cs
+++ b/Amplified.CSharp.Tests/AsyncMaybe/TaskCache.cs
@@ -1,0 +1,9 @@
+﻿using System.Threading.Tasks;
+
+namespace Amplified.CSharp
+{
+    internal static class TaskCache
+    {
+        internal static readonly Task CompletedTask = Task.FromResult<object>(null);
+    }
+}

--- a/Amplified.CSharp.Tests/Extensions/AsyncMaybe/Flatten.cs
+++ b/Amplified.CSharp.Tests/Extensions/AsyncMaybe/Flatten.cs
@@ -1,7 +1,6 @@
 using System.Threading.Tasks;
 using Amplified.CSharp.Extensions;
 using Xunit;
-using static Amplified.CSharp.Maybe;
 
 namespace Amplified.CSharp
 {

--- a/Amplified.CSharp.Tests/Extensions/AsyncMaybe/Map.cs
+++ b/Amplified.CSharp.Tests/Extensions/AsyncMaybe/Map.cs
@@ -2,7 +2,6 @@
 using Amplified.CSharp.Extensions;
 using Amplified.CSharp.Util;
 using Xunit;
-using static Amplified.CSharp.Maybe;
 
 namespace Amplified.CSharp
 {

--- a/Amplified.CSharp.Tests/Extensions/AsyncMaybe/MapAsync.cs
+++ b/Amplified.CSharp.Tests/Extensions/AsyncMaybe/MapAsync.cs
@@ -33,7 +33,7 @@ namespace Amplified.CSharp
         public async Task Some_Map_Action_T_Lambda_ReturnsSomeUnit()
         {
             var source = AsyncMaybe<int>.Some(5);
-            var result = await source.MapAsync(some => Task.CompletedTask);
+            var result = await source.MapAsync(some => TaskCache.CompletedTask);
             var unit = result.MustBeSome();
             Assert.IsType<Unit>(unit);
         }
@@ -41,7 +41,7 @@ namespace Amplified.CSharp
         [Fact]
         public async Task Some_Map_Action_T_MethodReference_ReturnsSomeUnit()
         {
-            Task Foo(int it) => Task.CompletedTask;
+            Task Foo(int it) => TaskCache.CompletedTask;
             var source = AsyncMaybe<int>.Some(5);
             var result = await source.MapAsync(Foo);
             var unit = result.MustBeSome();
@@ -53,7 +53,7 @@ namespace Amplified.CSharp
         {
             var rec = new Recorder();
             var source = AsyncMaybe<int>.Some(5);
-            var result = await source.MapAsync(rec.Record((int it) => Task.CompletedTask));
+            var result = await source.MapAsync(rec.Record((int it) => TaskCache.CompletedTask));
             result.MustBeSome();
             rec.MustHaveExactly(1.Invocations());
         }
@@ -63,7 +63,7 @@ namespace Amplified.CSharp
         {
             var rec = new Recorder();
             var source = AsyncMaybe<int>.None();
-            var result = await source.MapAsync(rec.Record((int it) => Task.CompletedTask));
+            var result = await source.MapAsync(rec.Record((int it) => TaskCache.CompletedTask));
             result.MustBeNone();
             rec.MustHaveExactly(0.Invocations());
         }
@@ -72,7 +72,7 @@ namespace Amplified.CSharp
         public async Task None_Map_Action_T__ReturnsNoneUnit()
         {
             var source = AsyncMaybe<int>.None();
-            var result = await source.MapAsync(it => Task.CompletedTask);
+            var result = await source.MapAsync(it => TaskCache.CompletedTask);
             result.MustBeNone();
         }
         
@@ -84,7 +84,7 @@ namespace Amplified.CSharp
         public async Task Some_Map_ActionLambda_ReturnsSomeUnit()
         {
             var source = AsyncMaybe<int>.Some(5);
-            var result = await source.MapAsync(() => Task.CompletedTask);
+            var result = await source.MapAsync(() => TaskCache.CompletedTask);
             var unit = result.MustBeSome();
             Assert.IsType<Unit>(unit);
         }
@@ -92,7 +92,7 @@ namespace Amplified.CSharp
         [Fact]
         public async Task Some_Map_ActionMethodReference_ReturnsSomeUnit()
         {
-            Task Foo() => Task.CompletedTask;
+            Task Foo() => TaskCache.CompletedTask;
             var source = AsyncMaybe<int>.Some(5);
             var result = await source.MapAsync(Foo);
             var unit = result.MustBeSome();
@@ -104,7 +104,7 @@ namespace Amplified.CSharp
         {
             var rec = new Recorder();
             var source = AsyncMaybe<int>.Some(5);
-            var result = await source.MapAsync(rec.Record(() => Task.CompletedTask));
+            var result = await source.MapAsync(rec.Record(() => TaskCache.CompletedTask));
             result.MustBeSome();
             rec.MustHaveExactly(1.Invocations());
         }
@@ -114,7 +114,7 @@ namespace Amplified.CSharp
         {
             var rec = new Recorder();
             var source = AsyncMaybe<int>.None();
-            var result = await source.MapAsync(rec.Record(() => Task.CompletedTask));
+            var result = await source.MapAsync(rec.Record(() => TaskCache.CompletedTask));
             result.MustBeNone();
             rec.MustHaveExactly(0.Invocations());
         }
@@ -123,7 +123,7 @@ namespace Amplified.CSharp
         public async Task None_Map_Action_ReturnsNoneUnit()
         {
             var source = AsyncMaybe<int>.None();
-            var result = await source.MapAsync(() => Task.CompletedTask);
+            var result = await source.MapAsync(() => TaskCache.CompletedTask);
             result.MustBeNone();
         }
         

--- a/Amplified.CSharp.Tests/Extensions/AsyncMaybe/Or.cs
+++ b/Amplified.CSharp.Tests/Extensions/AsyncMaybe/Or.cs
@@ -1,8 +1,6 @@
 using System.Threading.Tasks;
 using Amplified.CSharp.Extensions;
-using Amplified.CSharp.Util;
 using Xunit;
-using static Amplified.CSharp.Maybe;
 
 namespace Amplified.CSharp
 {

--- a/Amplified.CSharp.Tests/Extensions/Enumerable/ElementAtOrNone.cs
+++ b/Amplified.CSharp.Tests/Extensions/Enumerable/ElementAtOrNone.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Amplified.CSharp.Extensions;
-using Amplified.CSharp.Util;
 using Xunit;
 
 namespace Amplified.CSharp

--- a/Amplified.CSharp.Tests/Maybe/Constructors.cs
+++ b/Amplified.CSharp.Tests/Maybe/Constructors.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Threading.Tasks;
-using Amplified.CSharp.Util;
 using Xunit;
 
 namespace Amplified.CSharp

--- a/Amplified.CSharp.Tests/Maybe/Equals.cs
+++ b/Amplified.CSharp.Tests/Maybe/Equals.cs
@@ -1,4 +1,3 @@
-using System;
 using Xunit;
 
 namespace Amplified.CSharp

--- a/Amplified.CSharp.Tests/Maybe/Extensions/OrThrowAsync.cs
+++ b/Amplified.CSharp.Tests/Maybe/Extensions/OrThrowAsync.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Threading.Tasks;
 using Amplified.CSharp.Extensions;
 using Amplified.CSharp.Util;

--- a/Amplified.CSharp.Tests/Maybe/ToString.cs
+++ b/Amplified.CSharp.Tests/Maybe/ToString.cs
@@ -6,18 +6,18 @@ namespace Amplified.CSharp
     public class Maybe__ToString
     {
         [Fact]
-        public void WhenNone_ReturnsNameOfNoneType()
+        public void WhenNone_ReturnsEmptyString()
         {
             var source = Maybe<int>.None();
             var str = source.ToString();
-            Assert.Equal(nameof(None), str);
+            Assert.Equal(string.Empty, str);
         }
         
         [Fact]
-        public void WhenSome_ReturnsValueWrappedInSome()
+        public void WhenSome_ReturnsToStringOfValue()
         {
             var value = 1;
-            var expected = $"{nameof(Maybe<int>.Some)}({value})";
+            var expected = value.ToString();
             var source = Maybe<int>.Some(value);
             var str = source.ToString();
             Assert.Equal(expected, str);

--- a/Amplified.CSharp.Tests/None/ToString.cs
+++ b/Amplified.CSharp.Tests/None/ToString.cs
@@ -6,11 +6,11 @@ namespace Amplified.CSharp
     public class None__ToString
     {
         [Fact]
-        public void ReturnsNoneLiteral()
+        public void ReturnsEmptyString()
         {
             var source = new None();
             var str = source.ToString();
-            Assert.Equal(nameof(None), str);
+            Assert.Equal(string.Empty, str);
         }
     }
 }

--- a/Amplified.CSharp.Tests/TypeConversion/GetConverter.cs
+++ b/Amplified.CSharp.Tests/TypeConversion/GetConverter.cs
@@ -1,0 +1,180 @@
+﻿using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
+using Amplified.CSharp.ComponentModel;
+using Xunit;
+
+namespace Amplified.CSharp.TypeConversion
+{
+    public class GetConverter
+    {
+        [Fact]
+        public void ReturnsMaybeConverter()
+        {
+            var converter = TypeDescriptor.GetConverter(typeof(Maybe<int>));
+            Assert.IsType<MaybeConverter>(converter);
+        }
+        
+        [Fact]
+        public void TwiceForSameType_ReturnsSameConverter()
+        {
+            var converter1 = TypeDescriptor.GetConverter(typeof(Maybe<int>));
+            var converter2 = TypeDescriptor.GetConverter(typeof(Maybe<int>));
+            Assert.Same(converter1, converter2);
+        }
+        
+        [Fact]
+        public void ForDifferentTypes_ReturnsDifferentConverters()
+        {
+            var converter1 = TypeDescriptor.GetConverter(typeof(Maybe<int>));
+            var converter2 = TypeDescriptor.GetConverter(typeof(Maybe<object>));
+            Assert.NotSame(converter1, converter2);
+        }
+        
+        [Fact]
+        public void CanConvertFromInt()
+        {
+            var converter = TypeDescriptor.GetConverter(typeof(Maybe<int>));
+            var canConvert = converter.CanConvertFrom(typeof(int));
+            Assert.True(canConvert);
+        }
+        
+        [Fact]
+        public void ConvertFromInt()
+        {
+            const int expected = 5;
+            var converter = TypeDescriptor.GetConverter(typeof(Maybe<int>));
+            var value = converter.ConvertFrom(expected);
+            Assert.Equal(Maybe.Some(expected), value);
+        }
+
+        [Fact]
+        public void CanConvertFromNullableInt()
+        {
+            var converter = TypeDescriptor.GetConverter(typeof(Maybe<int>));
+            var canConvert = converter.CanConvertFrom(typeof(int?));
+            Assert.True(canConvert);
+        }
+        
+        [Fact]
+        public void ConvertFromNonNullNullableInt()
+        {
+            int? expected = 5;
+            var converter = TypeDescriptor.GetConverter(typeof(Maybe<int>));
+            var value = converter.ConvertFrom(expected);
+            Assert.Equal(Maybe.OfNullable(expected), value);
+        }
+        
+        [Fact]
+        [SuppressMessage("ReSharper", "ExpressionIsAlwaysNull")]
+        public void ConvertFromNullNullableInt()
+        {
+            int? expected = null;
+            var converter = TypeDescriptor.GetConverter(typeof(Maybe<int>));
+            var value = converter.ConvertFrom(expected);
+            Assert.Equal(Maybe.OfNullable(expected), value);
+        }
+
+        [Fact]
+        public void CanConvertToInt()
+        {
+            var converter = TypeDescriptor.GetConverter(typeof(Maybe<int>));
+            var canConvert = converter.CanConvertTo(typeof(int));
+            Assert.True(canConvert);
+        }
+
+        [Fact]
+        public void CanConvertToNullableInt()
+        {
+            var converter = TypeDescriptor.GetConverter(typeof(Maybe<int>));
+            var canConvert = converter.CanConvertTo(typeof(int?));
+            Assert.True(canConvert);
+        }
+
+        [Fact]
+        public void CanConvertFromObject()
+        {
+            var converter = TypeDescriptor.GetConverter(typeof(Maybe<object>));
+            var canConvert = converter.CanConvertFrom(typeof(object));
+            Assert.True(canConvert);
+        }
+
+        [Fact]
+        public void ConvertFromNonNullObject_IsSameInstance()
+        {
+            var expected = new object();
+            var converter = TypeDescriptor.GetConverter(typeof(Maybe<object>));
+            var result = converter.ConvertFrom(expected);
+            Assert.Equal(Maybe.Some(expected), result);
+        }
+
+        [Fact]
+        public void ConvertFromNullObject_ReturnsNone()
+        {
+            var converter = TypeDescriptor.GetConverter(typeof(Maybe<object>));
+            var result = converter.ConvertFrom(null);
+            Assert.Equal(Maybe.None(), result);
+        }
+
+        [Fact]
+        public void CanConvertToObject()
+        {
+            var converter = TypeDescriptor.GetConverter(typeof(Maybe<object>));
+            var canConvert = converter.CanConvertTo(typeof(object));
+            Assert.True(canConvert);
+        }
+
+        [Fact]
+        public void ConvertToNonNullObject()
+        {
+            var expected = new object();
+            var converter = TypeDescriptor.GetConverter(typeof(Maybe<object>));
+            var source = Maybe.Some(expected);
+            var result = converter.ConvertTo(source, typeof(object));
+            Assert.Same(expected, result);
+        }
+
+        [Fact]
+        public void ConvertToNullObject()
+        {
+            var converter = TypeDescriptor.GetConverter(typeof(Maybe<object>));
+            var source = Maybe.None<object>();
+            var result = converter.ConvertTo(source, typeof(object));
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void CanConvertFromString()
+        {
+            var converter = TypeDescriptor.GetConverter(typeof(Maybe<int>));
+            var canConvert = converter.CanConvertFrom(typeof(string));
+            Assert.True(canConvert);
+        }
+
+        [Fact]
+        public void ConvertFromString()
+        {
+            const string str = "25";
+            var converter = TypeDescriptor.GetConverter(typeof(Maybe<int>));
+            var result = converter.ConvertFrom(str);
+            Assert.Equal(Maybe.Some(25), result);
+        }
+
+        [Fact]
+        public void CanConvertToString()
+        {
+            var converter = TypeDescriptor.GetConverter(typeof(Maybe<int>));
+            var canConvert = converter.CanConvertTo(typeof(string));
+            Assert.True(canConvert);
+        }
+
+        [Fact]
+        public void ConvertToString()
+        {
+            const int expected = 25553;
+            var converter = TypeDescriptor.GetConverter(typeof(Maybe<int>));
+            var source = Maybe.Some(expected);
+            var result = converter.ConvertTo(source, typeof(string));
+            Assert.Equal($"{expected}", result);
+        }
+    }
+}

--- a/Amplified.CSharp.Tests/TypeConversion/GetConverter.cs
+++ b/Amplified.CSharp.Tests/TypeConversion/GetConverter.cs
@@ -1,4 +1,5 @@
-﻿using System.ComponentModel;
+﻿using System;
+using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 using Amplified.CSharp.ComponentModel;
 using Xunit;
@@ -58,10 +59,10 @@ namespace Amplified.CSharp.TypeConversion
         [Fact]
         public void ConvertFromNonNullNullableInt()
         {
-            int? expected = 5;
+            var expected = (int?) 5;
             var converter = TypeDescriptor.GetConverter(typeof(Maybe<int>));
-            var value = converter.ConvertFrom(expected);
-            Assert.Equal(Maybe.OfNullable(expected), value);
+            var result = (Maybe<int>) converter.ConvertFrom(expected);
+            Assert.Equal(expected, result.OrFail());
         }
         
         [Fact]
@@ -157,6 +158,23 @@ namespace Amplified.CSharp.TypeConversion
             var converter = TypeDescriptor.GetConverter(typeof(Maybe<int>));
             var result = converter.ConvertFrom(str);
             Assert.Equal(Maybe.Some(25), result);
+        }
+
+        [Fact]
+        public void ConvertFromEmptyString()
+        {
+            var converter = TypeDescriptor.GetConverter(typeof(Maybe<int>));
+            var result = (Maybe<int>) converter.ConvertFrom(string.Empty);
+            Assert.Equal(Maybe.None<int>(), result);
+        }
+
+        [Fact]
+        public void ConvertFromNullString()
+        {
+            string str = null;
+            var converter = TypeDescriptor.GetConverter(typeof(Maybe<int>));
+            var result = (Maybe<int>) converter.ConvertFrom(str);
+            Assert.Equal(Maybe.None<int>(), result);
         }
 
         [Fact]

--- a/Amplified.CSharp.Tests/TypeConversion/GetConverter.cs
+++ b/Amplified.CSharp.Tests/TypeConversion/GetConverter.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.ComponentModel;
+﻿using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 using Amplified.CSharp.ComponentModel;
 using Xunit;

--- a/Amplified.CSharp.Tests/Units/StaticConstructors.cs
+++ b/Amplified.CSharp.Tests/Units/StaticConstructors.cs
@@ -39,21 +39,21 @@ namespace Amplified.CSharp
         [Fact]
         public async Task WithLambdaAsFunc_Task_ReturnsFunc_Task_Unit()
         {
-            var result = await Units.UnitAsync(() => Task.CompletedTask);
+            var result = await Units.UnitAsync(() => TaskCache.CompletedTask);
             Assert.Equal(result, default(Unit));
         }
 
         [Fact]
         public async Task WithAsyncLambdaAsFunc_Task_ReturnsFunc_Task_Unit()
         {
-            var result = await Units.UnitAsync(async () => await Task.CompletedTask);
+            var result = await Units.UnitAsync(async () => await TaskCache.CompletedTask);
             Assert.Equal(result, default(Unit));
         }
 
         [Fact]
         public async Task WithMethodReferenceAsFunc_Task_ReturnsFunc_Task_Unit()
         {
-            Task Foo() => Task.CompletedTask;
+            Task Foo() => TaskCache.CompletedTask;
             var result = await Units.UnitAsync(Foo);
             Assert.Equal(result, default(Unit));
         }

--- a/Amplified.CSharp.Tests/Units/StaticConstructors.cs
+++ b/Amplified.CSharp.Tests/Units/StaticConstructors.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -30,9 +29,11 @@ namespace Amplified.CSharp
         [Fact]
         public void WithMethodReferenceAsAction_ReturnsFunc_Unit()
         {
-            void Foo() => Console.WriteLine("bar");
+            var output = string.Empty;
+            void Foo() => output = "bar";
             var result = Units.Unit(Foo);
             Assert.Equal(result, default(Unit));
+            Assert.Equal("bar", output);
         }
 
         [Fact]

--- a/Amplified.CSharp/Amplified.CSharp.csproj
+++ b/Amplified.CSharp/Amplified.CSharp.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.5;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard1.5;net452</TargetFrameworks>
     <DebugType>portable</DebugType>
     <AssemblyName>Amplified.CSharp</AssemblyName>
     <PackageId>Amplified.CSharp</PackageId>
@@ -21,11 +21,6 @@
     <Version>2.0.1</Version>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
   </PropertyGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net45'">
-    <Reference Include="System" />
-    <Reference Include="System.ComponentModel" />
-    <Reference Include="Microsoft.CSharp" />
-  </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.5'">
     <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.1.0" />
   </ItemGroup>

--- a/Amplified.CSharp/Amplified.CSharp.csproj
+++ b/Amplified.CSharp/Amplified.CSharp.csproj
@@ -27,7 +27,7 @@
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.5'">
-    <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
+    <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.1.0" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="src\Extensions\AsyncMaybe\Async" />

--- a/Amplified.CSharp/Amplified.CSharp.csproj
+++ b/Amplified.CSharp/Amplified.CSharp.csproj
@@ -9,7 +9,6 @@
     <PackageLicenseUrl>https://github.com/Nillerr/Amplified.CSharp/blob/master/LICENSE</PackageLicenseUrl>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/Nillerr/Amplified.CSharp</RepositoryUrl>
-    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.4' ">1.6.0</NetStandardImplicitPackageVersion>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>

--- a/Amplified.CSharp/Amplified.CSharp.csproj
+++ b/Amplified.CSharp/Amplified.CSharp.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.4;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard1.5;net45</TargetFrameworks>
     <DebugType>portable</DebugType>
     <AssemblyName>Amplified.CSharp</AssemblyName>
     <PackageId>Amplified.CSharp</PackageId>
@@ -21,9 +21,13 @@
     <Version>2.0.1</Version>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
   </PropertyGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net45'">
     <Reference Include="System" />
+    <Reference Include="System.ComponentModel" />
     <Reference Include="Microsoft.CSharp" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.5'">
+    <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="src\Extensions\AsyncMaybe\Async" />

--- a/Amplified.CSharp/src/ComponentModel/MaybeConverter.cs
+++ b/Amplified.CSharp/src/ComponentModel/MaybeConverter.cs
@@ -1,0 +1,307 @@
+﻿using System;
+using System.Collections;
+using System.ComponentModel;
+using System.Globalization;
+using System.Reflection;
+
+namespace Amplified.CSharp.ComponentModel
+{
+    public sealed class MaybeConverter : TypeConverter
+    {
+        private readonly TypeConverter _actualConverter;
+        
+        public MaybeConverter(Type actualType)
+        {
+            var valueType = actualType.GenericTypeArguments[0];
+            var actualConverterType = typeof(MaybeConverter<>).MakeGenericType(valueType);
+            _actualConverter = (TypeConverter) Activator.CreateInstance(actualConverterType);
+        }
+
+        public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
+            => _actualConverter.CanConvertFrom(context, sourceType);
+
+        public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
+            => _actualConverter.ConvertFrom(context, culture, value);
+
+        public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
+            => _actualConverter.CanConvertTo(context, destinationType);
+
+        public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType)
+            => _actualConverter.ConvertTo(context, culture, value, destinationType);
+
+        public override object CreateInstance(ITypeDescriptorContext context, IDictionary propertyValues)
+            => _actualConverter.CreateInstance(context, propertyValues);
+
+        public override bool GetCreateInstanceSupported(ITypeDescriptorContext context)
+            => _actualConverter.GetCreateInstanceSupported(context);
+
+        public override PropertyDescriptorCollection GetProperties(ITypeDescriptorContext context, object value, Attribute[] attributes)
+            => _actualConverter.GetProperties(context, value, attributes);
+
+        public override bool GetPropertiesSupported(ITypeDescriptorContext context)
+            => _actualConverter.GetPropertiesSupported(context);
+
+        public override StandardValuesCollection GetStandardValues(ITypeDescriptorContext context)
+            => _actualConverter.GetStandardValues(context);
+
+        public override bool GetStandardValuesExclusive(ITypeDescriptorContext context)
+            => _actualConverter.GetStandardValuesExclusive(context);
+
+        public override bool GetStandardValuesSupported(ITypeDescriptorContext context)
+            => _actualConverter.GetStandardValuesSupported(context);
+
+        public override bool IsValid(ITypeDescriptorContext context, object value)
+            => _actualConverter.IsValid(context, value);
+    }
+
+    public sealed class MaybeConverter<T> : TypeConverter
+    {
+        public MaybeConverter()
+        {
+            MaybeType = typeof(Maybe<T>);
+            ValueType = typeof(T);
+            ValueConverter = TypeDescriptor.GetConverter(ValueType);
+        }
+        
+        public Type MaybeType { get; }
+        
+        public Type ValueType { get; }
+        
+        public TypeConverter ValueConverter { get; }
+
+        /// <summary>
+        ///     Converts an anonymous object to either a Maybe.Some when the object is non-null, or a Maybe.None when 
+        ///     the object is null. 
+        /// </summary>
+        private static Maybe<T> NullableToMaybe(object value)
+        {
+            return value != null ? Maybe<T>.Some((T) value) : Maybe<T>.None();
+        }
+
+        private static bool IsNullableType(Type type)
+        {
+            return !type.GetTypeInfo().IsValueType || Nullable.GetUnderlyingType(type) != null;
+        }
+
+        /// <summary>
+        ///    <para>Gets a value indicating whether this converter can convert an object in the
+        ///       given source type to the underlying simple type or a Maybe.None.</para>
+        /// </summary>
+        public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
+        {
+            if (sourceType == ValueType)
+                return true;
+            
+            if (ValueConverter != null)
+                return ValueConverter.CanConvertFrom(context, sourceType);
+            
+            return base.CanConvertFrom(context, sourceType);
+        }
+
+        /// <summary>
+        ///    Converts the given value to the converter's underlying simple type and wraps it in a Maybe.Some or a Maybe.None.
+        /// </summary>
+        public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
+        {
+            if (value == null)
+                return Maybe<T>.None();
+
+            if (value.GetType() == ValueType)
+                return Maybe<T>.Some((T) value);
+
+            var stringValue = value as string;
+            if (stringValue != null && string.IsNullOrEmpty(stringValue))
+                return Maybe<T>.None();
+
+            if (ValueConverter != null)
+            {
+                var convertedValue = (T) ValueConverter.ConvertFrom(context, culture, value);
+                return Maybe<T>.Some(convertedValue);
+            }
+
+            return base.ConvertFrom(context, culture, value);
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether this converter can convert a value object to the destination type.
+        /// </summary>
+        public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
+        {
+            if (destinationType == ValueType)
+                return true;
+
+            if (ValueConverter != null)
+                return ValueConverter.CanConvertTo(context, destinationType);
+
+            return base.CanConvertTo(context, destinationType);
+        }
+
+        /// <summary>
+        /// Converts the given value object to the destination type.
+        /// </summary>
+        public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType)
+        {
+            if (destinationType == null)
+                throw new ArgumentNullException(nameof(destinationType));
+
+            var maybeValue = (Maybe<T>) value;
+            return maybeValue.Match(
+                some => ConvertSomeTo(context, culture, some, destinationType),
+                () => ConvertNoneTo(context, culture, destinationType)
+            );
+        }
+
+        private object ConvertSomeTo(ITypeDescriptorContext context, CultureInfo culture, T value, Type destinationType)
+        {
+            if (value.GetType() == destinationType)
+                return value;
+            
+            if (ValueConverter != null)
+                return ValueConverter.ConvertTo(context, culture, value, destinationType);
+
+            return base.ConvertTo(context, culture, value, destinationType);
+        }
+
+        private object ConvertNoneTo(ITypeDescriptorContext context, CultureInfo culture, Type destinationType)
+        {
+            if (destinationType == typeof(string))
+                return string.Empty;
+            
+            if (IsNullableType(destinationType))
+                return null;
+
+            return base.ConvertTo(context, culture, null, destinationType);
+        }
+
+        /// <summary>
+        /// </summary>
+        public override object CreateInstance(ITypeDescriptorContext context, IDictionary propertyValues)
+        {
+            if (ValueConverter != null)
+            {
+                var instance = ValueConverter.CreateInstance(context, propertyValues);
+                var maybe = NullableToMaybe(instance);
+                return maybe;
+            }
+            
+            return base.CreateInstance(context, propertyValues);
+        }
+
+        /// <summary>
+        ///    <para>
+        ///        Gets a value indicating whether changing a value on this object requires a call to
+        ///        <see cref='System.ComponentModel.TypeConverter.CreateInstance'/> to create a new value,
+        ///        using the specified context.
+        ///    </para>
+        /// </summary>
+        public override bool GetCreateInstanceSupported(ITypeDescriptorContext context)
+        {
+            if (ValueConverter != null)
+            {
+                return ValueConverter.GetCreateInstanceSupported(context);
+            }
+
+            return base.GetCreateInstanceSupported(context);
+        }
+
+        /// <summary>
+        ///    <para>
+        ///        Gets a collection of properties for the type of array specified by the value
+        ///        parameter using the specified context and attributes.
+        ///    </para>
+        /// </summary>
+        public override PropertyDescriptorCollection GetProperties(ITypeDescriptorContext context, object value, Attribute[] attributes)
+        {
+            if (ValueConverter != null)
+            {
+                var unwrappedValue = ((Maybe<T>) value).Match(some => (object) some, none => null);
+                return ValueConverter.GetProperties(context, unwrappedValue, attributes);
+            }
+
+            return base.GetProperties(context, value, attributes);
+        }
+
+        /// <summary>
+        ///    <para>Gets a value indicating whether this object supports properties using the specified context.</para>
+        /// </summary>
+        public override bool GetPropertiesSupported(ITypeDescriptorContext context)
+        {
+            if (ValueConverter != null)
+            {
+                return ValueConverter.GetPropertiesSupported(context);
+            }
+
+            return base.GetPropertiesSupported(context);
+        }
+
+        /// <summary>
+        ///    <para>Gets a collection of standard values for the data type this type converter is designed for.</para>
+        /// </summary>
+        public override StandardValuesCollection GetStandardValues(ITypeDescriptorContext context)
+        {
+            if (ValueConverter != null)
+            {
+                var values = ValueConverter.GetStandardValues(context);
+                if (GetStandardValuesSupported(context) && values != null)
+                {
+                    // Create set of standard values around Maybe instances.
+                    var wrappedValues = new Maybe<T>[values.Count + 1];
+                    var idx = 0;
+
+                    wrappedValues[idx++] = Maybe<T>.None();
+                    foreach (var value in values)
+                        wrappedValues[idx++] = NullableToMaybe(value);
+
+                    return new StandardValuesCollection(wrappedValues);
+                }
+            }
+            
+            return base.GetStandardValues(context);
+        }
+        
+        /// <summary>
+        ///    <para>
+        ///        Gets a value indicating whether the collection of standard values returned from
+        ///        <see cref='System.ComponentModel.TypeConverter.GetStandardValues'/> is an exclusive 
+        ///        list of possible values, using the specified context.
+        ///    </para>
+        /// </summary>
+        public override bool GetStandardValuesExclusive(ITypeDescriptorContext context)
+        {
+            if (ValueConverter != null)
+                return ValueConverter.GetStandardValuesExclusive(context);
+
+            return base.GetStandardValuesExclusive(context);
+        }
+
+        /// <summary>
+        ///    <para>
+        ///        Gets a value indicating whether this object supports a standard set of values that can
+        ///        be picked from a list using the specified context.
+        ///    </para>
+        /// </summary>
+        public override bool GetStandardValuesSupported(ITypeDescriptorContext context)
+        {
+            if (ValueConverter != null)
+                return ValueConverter.GetStandardValuesSupported(context);
+
+            return base.GetStandardValuesSupported(context);
+        }
+
+        /// <summary>
+        ///    <para>Gets a value indicating whether the given value object is valid for this type.</para>
+        /// </summary>
+        public override bool IsValid(ITypeDescriptorContext context, object value)
+        {
+            if (ValueConverter != null)
+            {
+                if (value == null)
+                    return true;
+
+                return ValueConverter.IsValid(context, value);
+            }
+            
+            return base.IsValid(context, value);
+        }
+    }
+}

--- a/Amplified.CSharp/src/Extensions/AsyncMaybe/AsyncMaybeFilter.cs
+++ b/Amplified.CSharp/src/Extensions/AsyncMaybe/AsyncMaybeFilter.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Threading.Tasks;
 using JetBrains.Annotations;
 
 namespace Amplified.CSharp.Extensions

--- a/Amplified.CSharp/src/Extensions/AsyncMaybe/AsyncMaybeMap.cs
+++ b/Amplified.CSharp/src/Extensions/AsyncMaybe/AsyncMaybeMap.cs
@@ -1,6 +1,5 @@
 using System;
 using JetBrains.Annotations;
-using static Amplified.CSharp.Maybe;
 
 namespace Amplified.CSharp.Extensions
 {

--- a/Amplified.CSharp/src/Extensions/AsyncMaybe/AsyncMaybeOr.cs
+++ b/Amplified.CSharp/src/Extensions/AsyncMaybe/AsyncMaybeOr.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Threading.Tasks;
-using Amplified.CSharp.Internal.Extensions;
 using JetBrains.Annotations;
 using static Amplified.CSharp.Maybe;
 

--- a/Amplified.CSharp/src/Extensions/Enumerable/EnumerableToMaybe.cs
+++ b/Amplified.CSharp/src/Extensions/Enumerable/EnumerableToMaybe.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace Amplified.CSharp.Extensions
 {

--- a/Amplified.CSharp/src/Extensions/Maybe/Async/MaybeMapAsync.cs
+++ b/Amplified.CSharp/src/Extensions/Maybe/Async/MaybeMapAsync.cs
@@ -2,7 +2,6 @@ using System;
 using System.Threading.Tasks;
 using Amplified.CSharp.Internal.Extensions;
 using JetBrains.Annotations;
-using static Amplified.CSharp.Maybe;
 
 namespace Amplified.CSharp.Extensions
 {

--- a/Amplified.CSharp/src/Extensions/Maybe/MaybeOr.cs
+++ b/Amplified.CSharp/src/Extensions/Maybe/MaybeOr.cs
@@ -1,6 +1,4 @@
 using System;
-using System.Threading.Tasks;
-using Amplified.CSharp.Internal.Extensions;
 using JetBrains.Annotations;
 using static Amplified.CSharp.Maybe;
 

--- a/Amplified.CSharp/src/Internal/IAsyncCanBeNone.cs
+++ b/Amplified.CSharp/src/Internal/IAsyncCanBeNone.cs
@@ -1,9 +1,0 @@
-using System.Threading.Tasks;
-
-namespace Amplified.CSharp.Internal
-{
-    public interface IAsyncCanBeNone
-    {
-        Task<bool> IsNoneAsync { get; }
-    }
-}

--- a/Amplified.CSharp/src/Maybe.cs
+++ b/Amplified.CSharp/src/Maybe.cs
@@ -18,8 +18,9 @@ namespace Amplified.CSharp
     ///   </para>
     /// </summary>
     /// <typeparam name="T"></typeparam>
-    [DebuggerStepThrough]
+    [Serializable]
     [TypeConverter(typeof(MaybeConverter))]
+    [DebuggerStepThrough]
     [DebuggerDisplay("{" + nameof(DebuggerDisplayString) + "}")]
     public struct Maybe<T> : IMaybe, IEquatable<Maybe<T>>
     {

--- a/Amplified.CSharp/src/Maybe.cs
+++ b/Amplified.CSharp/src/Maybe.cs
@@ -18,7 +18,6 @@ namespace Amplified.CSharp
     ///   </para>
     /// </summary>
     /// <typeparam name="T"></typeparam>
-    [Serializable]
     [TypeConverter(typeof(MaybeConverter))]
     [DebuggerStepThrough]
     [DebuggerDisplay("{" + nameof(DebuggerDisplayString) + "}")]

--- a/Amplified.CSharp/src/Maybe.cs
+++ b/Amplified.CSharp/src/Maybe.cs
@@ -12,23 +12,26 @@ using JetBrains.Annotations;
 namespace Amplified.CSharp
 {
     /// <summary>
+    ///   <para>
     ///     Maybe represents the possibility of a value being present. It is equivalent to <c>null</c> for reference
     ///     types, but being a <c>struct</c>, it can never be <c>null</c> itself (unless it is boxed).
+    ///   </para>
     /// </summary>
     /// <typeparam name="T"></typeparam>
     [DebuggerStepThrough]
     [TypeConverter(typeof(MaybeConverter))]
+    [DebuggerDisplay("{" + nameof(DebuggerDisplayString) + "}")]
     public struct Maybe<T> : IMaybe, IEquatable<Maybe<T>>
     {
         /// <summary>
-        /// Returns a <c>None</c> instance (a <see cref="Maybe{T}"/> without a value).
+        ///   <para>Returns a <c>None</c> instance (a <see cref="Maybe{T}"/> without a value).</para>
         /// </summary>
         /// <returns>A <see cref="Maybe{T}"/>.<c>None</c>.</returns>
         [Pure]
         public static Maybe<T> None() => default(Maybe<T>);
 
         /// <summary>
-        /// Creates a Some case using <see cref="value"/>.
+        ///   <para>Creates a Some case using <see cref="value"/>.</para>
         /// </summary>
         /// <param name="value"></param>
         /// <returns>A <see cref="Maybe{T}"/>.<c>Some</c> with a value.</returns>
@@ -37,6 +40,8 @@ namespace Amplified.CSharp
         {
             return new Maybe<T>(value);
         }
+
+        private string DebuggerDisplayString => Match(some => $"Some({some})", none => none.ToString());
 
         private readonly T _value;
 
@@ -50,10 +55,10 @@ namespace Amplified.CSharp
         }
 
         /// <summary>
-        /// Converts an instance of <see cref="None"/> to <see cref="Maybe{T}"/>.<c>None</c>.
+        ///   <para>Converts an instance of <see cref="None"/> to <see cref="Maybe{T}"/>.<c>None</c>.</para>
         /// </summary>
         /// <remarks>
-        /// This operator is required to support type-parameterless Maybe.None construction.
+        ///   <para>This operator is required to support type-parameterless Maybe.None construction.</para>
         /// </remarks>
         [Pure]
         public static implicit operator Maybe<T>(None none)
@@ -62,17 +67,27 @@ namespace Amplified.CSharp
         }
 
         /// <summary>
-        /// Returns <c>true</c> if the instance contains a value.
+        ///   <para>Returns <c>true</c> if the instance contains a value.</para>
         /// </summary>
         [Pure]
         public bool IsSome { get; }
         
         /// <summary>
-        /// Returns <c>false</c> if the instance does not contain a value.
+        ///   <para>Returns <c>false</c> if the instance does not contain a value.</para>
         /// </summary>
         [Pure]
         public bool IsNone => IsSome == false;
 
+        /// <summary>
+        ///   <para>
+        ///     Evaluates the value of the <c>Maybe</c>, resulting in either <paramref name="some"/> or 
+        ///     <paramref name="none"/> being invoked, depending on the value of the <c>Maybe</c>.
+        ///   </para>
+        /// </summary>
+        /// <param name="some">Function to invoke if the <c>Maybe</c> is <c>Some</c>.</param>
+        /// <param name="none">Function to invoke if the <c>Maybe</c> is <c>None</c>.</param>
+        /// <typeparam name="TResult">Type of result to return from the function arguments.</typeparam>
+        /// <returns>The result of calling either <paramref name="some"/> or <paramref name="none"/>.</returns>
         [Pure]
         public TResult Match<TResult>(
             [InstantHandle, NotNull] Func<T, TResult> some,
@@ -82,6 +97,16 @@ namespace Amplified.CSharp
             return IsSome ? some(_value) : none(default(None));
         }
 
+        /// <summary>
+        ///   <para>
+        ///     Evaluates the value of the <c>Maybe</c>, resulting in either <paramref name="some"/> or 
+        ///     <paramref name="none"/> being invoked, depending on the value of the <c>Maybe</c>.
+        ///   </para>
+        /// </summary>
+        /// <param name="some">Function to invoke if the <c>Maybe</c> is <c>Some</c>.</param>
+        /// <param name="none">Function to invoke if the <c>Maybe</c> is <c>None</c>.</param>
+        /// <typeparam name="TResult">Type of result to return from the function arguments.</typeparam>
+        /// <returns>The result of calling either <paramref name="some"/> or <paramref name="none"/>.</returns>
         [Pure]
         public TResult Match<TResult>(
             [InstantHandle, NotNull] Func<T, TResult> some,
@@ -91,6 +116,14 @@ namespace Amplified.CSharp
             return IsSome ? some(_value) : none();
         }
 
+        /// <summary>
+        ///   <para>
+        ///     Evaluates the value of the <c>Maybe</c>, resulting in either <paramref name="some"/> or 
+        ///     <paramref name="none"/> being invoked, depending on the value of the <c>Maybe</c>.
+        ///   </para>
+        /// </summary>
+        /// <param name="some">Action to invoke if the <c>Maybe</c> is <c>Some</c>.</param>
+        /// <param name="none">Actiono to invoke if the <c>Maybe</c> is <c>None</c>.</param>
         public Unit Match(
             [InstantHandle, NotNull] Action<T> some,
             [InstantHandle, NotNull] Action<None> none
@@ -104,6 +137,14 @@ namespace Amplified.CSharp
             return default(Unit);
         }
 
+        /// <summary>
+        ///   <para>
+        ///     Evaluates the value of the <c>Maybe</c>, resulting in either <paramref name="some"/> or 
+        ///     <paramref name="none"/> being invoked, depending on the value of the <c>Maybe</c>.
+        ///   </para>
+        /// </summary>
+        /// <param name="some">Action to invoke if the <c>Maybe</c> is <c>Some</c>.</param>
+        /// <param name="none">Actiono to invoke if the <c>Maybe</c> is <c>None</c>.</param>
         public Unit Match(
             [InstantHandle, NotNull] Action<T> some,
             [InstantHandle, NotNull] Action none
@@ -117,6 +158,12 @@ namespace Amplified.CSharp
             return default(Unit);
         }
 
+        /// <summary>
+        ///   <para>
+        ///     Evaluates the value of the <c>Maybe</c>, invoking <paramref name="some"/> if the value is <c>Some</c>.
+        ///   </para>
+        /// </summary>
+        /// <param name="some">Action to invoke if the <c>Maybe</c> is <c>Some</c>.</param>
         public Unit MatchSome([InstantHandle, NotNull] Action<T> some)
         {
             if (IsSome)
@@ -125,6 +172,12 @@ namespace Amplified.CSharp
             return default(Unit);
         }
 
+        /// <summary>
+        ///   <para>
+        ///     Evaluates the value of the <c>Maybe</c>, invoking <paramref name="none"/> if the value is <c>None</c>.
+        ///   </para>
+        /// </summary>
+        /// <param name="none">Action to invoke if the <c>Maybe</c> is <c>None</c>.</param>
         public Unit MatchNone([InstantHandle, NotNull] Action<None> none)
         {
             if (IsNone)
@@ -133,6 +186,12 @@ namespace Amplified.CSharp
             return default(Unit);
         }
 
+        /// <summary>
+        ///   <para>
+        ///     Evaluates the value of the <c>Maybe</c>, invoking <paramref name="none"/> if the value is <c>None</c>.
+        ///   </para>
+        /// </summary>
+        /// <param name="none">Action to invoke if the <c>Maybe</c> is <c>None</c>.</param>
         public Unit MatchNone([InstantHandle, NotNull] Action none)
         {
             if (IsNone)
@@ -141,6 +200,24 @@ namespace Amplified.CSharp
             return default(Unit);
         }
 
+        /// <summary>
+        ///   <para>
+        ///     Indicates whether the current <c>Maybe</c> is equal to another <c>Maybe</c> of the same type.
+        ///   </para>
+        /// </summary>
+        /// <param name="other">A <c>Maybe</c> to compare with this <c>Maybe</c>.</param>
+        /// <remarks>
+        ///   <para>
+        ///     Two instances of <c>Maybe</c> are equal if they are both <c>None</c>, or both <c>Some</c> and their 
+        ///     values are equal.
+        ///   </para>
+        /// </remarks>
+        /// <returns>
+        ///   <para>
+        ///     <see langword="true"/> if the <c>Maybe</c> is equal to <paramref name="other"/> parameter; otherwise, 
+        ///     <see langword="false"/>.
+        ///   </para>
+        /// </returns>
         [Pure]
         public bool Equals(Maybe<T> other)
         {
@@ -148,6 +225,26 @@ namespace Amplified.CSharp
                    (IsSome && other.IsSome && EqualityComparer<T>.Default.Equals(_value, other._value));
         }
 
+        /// <summary>
+        ///   <para>
+        ///     Indicates whether the current <c>Maybe</c> is equal to another <c>Maybe</c> of the same type, or an 
+        ///     instance of <c>None</c>.
+        ///   </para>
+        /// </summary>
+        /// <param name="obj">The object to compare with the current object.</param>
+        /// <remarks>
+        ///   <para>
+        ///     Two instances of <c>Maybe</c> are equal if they are both <c>None</c>, or both <c>Some</c> and their 
+        ///     values are equal. When comparing a <c>Maybe</c> to <c>None</c>, they are equal if the <c>Maybe</c> is 
+        ///     None.
+        ///   </para>
+        /// </remarks>
+        /// <returns>
+        ///   <para>
+        ///     <see langword="true"/> if the <c>Maybe</c> is equal to <paramref name="obj"/> parameter; otherwise, 
+        ///     <see langword="false"/>.
+        ///   </para>
+        /// </returns>
         [Pure]
         public override bool Equals(object obj)
         {
@@ -156,6 +253,8 @@ namespace Amplified.CSharp
                    (obj is None && Equals((None) obj));
         }
 
+        /// <summary>Returns the hash code for this instance.</summary>
+        /// <returns>A 32-bit signed integer that is the hash code for this instance.</returns>
         [Pure]
         public override int GetHashCode()
         {
@@ -167,12 +266,36 @@ namespace Amplified.CSharp
             }
         }
 
+        /// <summary>
+        ///   <para>Indicates whether two instances of <c>Maybe</c> are equal.</para>
+        /// </summary>
+        /// <remarks>
+        ///   <para>
+        ///     Two instances of <c>Maybe</c> are equal if they are both <c>None</c>, or both <c>Some</c> and their 
+        ///     values are equal.
+        ///   </para>
+        /// </remarks>
+        /// <returns>
+        ///   <para><see langword="true"/> if the instances are equal; otherwise, <see langword="false"/>.</para>
+        /// </returns>
         [Pure]
         public static bool operator ==(Maybe<T> left, Maybe<T> right)
         {
             return left.Equals(right);
         }
 
+        /// <summary>
+        ///   <para>Indicates whether two instances of <c>Maybe</c> are not equal.</para>
+        /// </summary>
+        /// <remarks>
+        ///   <para>
+        ///     Two instances of <c>Maybe</c> are equal if they are both <c>None</c>, or both <c>Some</c> and their 
+        ///     values are equal.
+        ///   </para>
+        /// </remarks>
+        /// <returns>
+        ///   <para><see langword="true"/> if the instances are not equal; otherwise, <see langword="false"/>.</para>
+        /// </returns>
         [Pure]
         public static bool operator !=(Maybe<T> left, Maybe<T> right)
         {
@@ -183,8 +306,8 @@ namespace Amplified.CSharp
         public override string ToString()
         {
             return Match(
-                some => $"Some({some})",
-                none => "None"
+                some => some.ToString(),
+                none => string.Empty
             );
         }
     }

--- a/Amplified.CSharp/src/Maybe.cs
+++ b/Amplified.CSharp/src/Maybe.cs
@@ -1,8 +1,10 @@
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Globalization;
 using System.Threading.Tasks;
+using Amplified.CSharp.ComponentModel;
 using Amplified.CSharp.Internal;
 using Amplified.CSharp.Internal.Extensions;
 using JetBrains.Annotations;
@@ -15,6 +17,7 @@ namespace Amplified.CSharp
     /// </summary>
     /// <typeparam name="T"></typeparam>
     [DebuggerStepThrough]
+    [TypeConverter(typeof(MaybeConverter))]
     public struct Maybe<T> : IMaybe, IEquatable<Maybe<T>>
     {
         /// <summary>

--- a/Amplified.CSharp/src/None.cs
+++ b/Amplified.CSharp/src/None.cs
@@ -15,6 +15,7 @@ namespace Amplified.CSharp
     ///     for other types by implementing <c>ICanBeNone</c> or <c>IMaybe</c>.
     /// </remarks>
     [DebuggerStepThrough]
+    [DebuggerDisplay("None")]
     public struct None : IEquatable<None>, IEquatable<IMaybe>
     {
         [Pure]
@@ -93,7 +94,7 @@ namespace Amplified.CSharp
         [Pure]
         public override string ToString()
         {
-            return nameof(None);
+            return string.Empty;
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # Amplified.CSharp
+# Amplified.Monads.Maybe
+
+Part of __Amplified.Monads__
 
 ![NuGet](https://img.shields.io/nuget/v/Amplified.CSharp.svg) ![Build status](https://ci.appveyor.com/api/projects/status/penxirmcfh2mhjxt/branch/master?svg=true)
 


### PR DESCRIPTION
A non-generic TypeConverter that creates and uses a generic TypeConverter whenever it encounters a new constructed generic type of `Maybe<T>`.

The converter supports the following use cases when converting _from_ other types:

**Value Types**

- Converts `T` to `Maybe<T>.Some(T)`.
- Converts `Nullable<T>` with a `null` value to `Maybe<T>.None()`.
- Converts `Nullable<T>` with a non-`null` value to `Maybe<T>.Some(T)`.

**Reference Types**

- Converts `non-null` instances of `T` to `Maybe<T>.Some(T)`.
- Converts `null` references of `T` to `Maybe<T>.None()`.
- Converts empty strings to `Maybe<T>.None()`.

The same conversions are applied in reverse when converting _to_ other types.

The implementation is based on [corefx/NullableConverter.cs](https://github.com/dotnet/corefx/blob/master/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/NullableConverter.cs).